### PR TITLE
setup.py should include qbuf dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name='txmysql',
       ],
       install_requires=[
           'setuptools',
+          'qbuf',
           ],
       zip_safe=False,
 )


### PR DESCRIPTION
setup.py should include qbuf dependency so installers can satisfy this.
